### PR TITLE
Devanagari Om fixed

### DIFF
--- a/themes/dogenpunk.zsh-theme
+++ b/themes/dogenpunk.zsh-theme
@@ -9,7 +9,7 @@
 MODE_INDICATOR="%{$fg_bold[red]%}❮%{$reset_color%}%{$fg[red]%}❮❮%{$reset_color%}"
 local return_status="%{$fg[red]%}%(?..⏎)%{$reset_color%}"
 
-PROMPT='%{$fg[blue]%}%m%{$reset_color%}%{$fg_bold[white]%} ओम् %{$reset_color%}%{$fg[cyan]%}%~:%{$reset_color%}$(git_time_since_commit)$(git_prompt_info)
+PROMPT='%{$fg[blue]%}%m%{$reset_color%}%{$fg_bold[white]%} ओम %{$reset_color%}%{$fg[cyan]%}%~:%{$reset_color%}$(git_time_since_commit)$(git_prompt_info)
 %{$fg[red]%}%!%{$reset_color%} $(prompt_char) '
 
 ZSH_THEME_GIT_PROMPT_PREFIX="%{$fg_bold[green]%}git%{$reset_color%}@%{$bg[white]%}%{$fg[black]%}"


### PR DESCRIPTION
I removed the incorrect Devanagari conjunct symbol at end of Om. The dash below the letter indicates that it should join the previous letter, which is not needed in spelling Om. 